### PR TITLE
Fix isPossible() missing in TS type

### DIFF
--- a/lib/rodnecislo.d.ts
+++ b/lib/rodnecislo.d.ts
@@ -1,6 +1,7 @@
 export function rodnecislo(rc: string): RodneCislo;
 
 export interface RodneCislo {
+  isPossible(): boolean
   isValid(): boolean
 
   isMale(): boolean

--- a/src/lib/rodnecislo.d.ts
+++ b/src/lib/rodnecislo.d.ts
@@ -1,6 +1,7 @@
 export function rodnecislo(rc: string): RodneCislo;
 
 export interface RodneCislo {
+  isPossible(): boolean
   isValid(): boolean
 
   isMale(): boolean


### PR DESCRIPTION
@kub1x `RodneCislo.isPossible()` method is currently missing in Typescript definition.